### PR TITLE
fix: change logout button position on profile page

### DIFF
--- a/lib/src/modules/profile/ui/pages/profile_page.dart
+++ b/lib/src/modules/profile/ui/pages/profile_page.dart
@@ -58,17 +58,6 @@ class _ProfilePageState extends State<ProfilePage> {
         foregroundColor: Colors.white,
       ),
       backgroundColor: PrimaryColors.brand,
-      persistentFooterButtons: [
-        Padding(
-          padding: const EdgeInsets.all(12.0),
-          child: SolidButton.transparent(
-            label: 'Sair da conta',
-            icon: PhosphorIconsRegular.signOut,
-            foregroundColor: SemanticColors.negative,
-            onPressed: logout,
-          ),
-        ),
-      ],
       body: user == null
           ? Container(color: MonoChromaticColors.backgroundColor)
           : Column(
@@ -145,6 +134,13 @@ class _ProfilePageState extends State<ProfilePage> {
                             icon: PhosphorIconsRegular.question,
                             style: SolidButtonStyle.outlined,
                             onPressed: () => context.push(QuestionPage.route),
+                          ),
+                          const SizedBox(height: 24),
+                          SolidButton.transparent(
+                            label: 'Sair da conta',
+                            icon: PhosphorIconsRegular.signOut,
+                            foregroundColor: SemanticColors.negative,
+                            onPressed: logout,
                           ),
                         ],
                       ),


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Change the position of the logout button on the profile page

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No
- [ ] I need help with writing tests